### PR TITLE
Problem with fileinfo: metadata injection

### DIFF
--- a/lib/pandocomatic/fileinfo_preprocessor.rb
+++ b/lib/pandocomatic/fileinfo_preprocessor.rb
@@ -26,12 +26,12 @@ module Pandocomatic
       created_at = File.stat(path).ctime
       modified_at = File.stat(path).mtime
       output = input
-      output << "\n---\n"
+      output << "\n\n---\n"
       output << "fileinfo:\n"
       output << "  path: '#{path}'\n"
       output << "  created: #{created_at.strftime '%Y-%m-%d'}\n"
       output << "  modified: #{modified_at.strftime '%Y-%m-%d'}\n"
-      output << "..."
+      output << "...\n\n"
     end
   end
 end


### PR DESCRIPTION
When no newline at document end injecting this metadata causes the document to become mangled. See #22 for details.

This fix adds more newlines before and after the injected metadata to ensure it won't get misparsed